### PR TITLE
docs: add agent_tools platform specification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,15 @@ and predictable error handling.
 ## Important References
 
 - `README.md`: project overview and current documentation map.
+- `docs/AGENT_TOOLS_PLATFORM_SPEC.md`: architectural contract every `*li`
+  tool should converge toward (envelope, errors, mutation safety,
+  selectors, taxonomy, maturity ladder). Read this before designing or
+  reviewing any tool change.
 - `docs/tooli.md`: concise guide for building Python CLIs with `tooli`.
 - `docs/skills.md`: skill authoring guide and local skills inventory.
 - `docs/tool-roadmap.md`: tool family inventory, standards, and legacy tool
   notes.
+- `docs/error-registry.md`: cross-tool error code registry.
 - `tooli_feedback.md`: actionable feedback for `tooli` and agent-tool
   usability.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,13 @@ workflows. Read `AGENTS.md` first; it is the canonical repo instruction file.
 Key references:
 
 - `README.md`: project overview and documentation map.
+- `docs/AGENT_TOOLS_PLATFORM_SPEC.md`: platform contract — envelope,
+  error taxonomy, mutation safety, selectors, tool family taxonomy,
+  maturity ladder. Authoritative for cross-tool design questions.
 - `docs/tooli.md`: `tooli` development guide.
 - `docs/skills.md`: skill authoring guide and skills inventory.
 - `docs/tool-roadmap.md`: tool inventory and roadmap.
+- `docs/error-registry.md`: cross-tool error code registry.
 - `tooli_feedback.md`: `tooli` and agent-tool feedback log.
 
 When you find stale docs, missing commands, confusing errors, or opportunities to

--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ Useful entry points:
 ## Common Design Language
 
 Across the repo, tools aim to share the same agent-friendly contract:
+JSON-first envelopes, stable error codes with recovery hints, dry-run
+plans before mutation, atomic writes with preimage protection, and stable
+selectors over visible names.
+
+The full contract — success/error envelope shape, shared error families,
+mutation safety lifecycle, selector model, tool taxonomy, and maturity
+ladder — lives in [`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](docs/AGENT_TOOLS_PLATFORM_SPEC.md).
+Read that before designing a new `*li` tool or auditing an existing one.
+
+A short sketch of the shared envelope (see spec §4.4 and §4.5 for the
+authoritative form, including `meta.annotations` and the
+`suggestion`/`is_retryable` error fields):
 
 ```json
 {
@@ -182,19 +194,6 @@ Across the repo, tools aim to share the same agent-friendly contract:
     "tool": "example.command",
     "duration_ms": 12,
     "dry_run": false
-  }
-}
-```
-
-When a command fails, the ideal output is just as parseable:
-
-```json
-{
-  "ok": false,
-  "error": {
-    "code": "VALIDATION_FAILED",
-    "message": "The requested range is invalid.",
-    "suggestion": "Check the sheet name and A1 range."
   }
 }
 ```
@@ -224,6 +223,11 @@ cargo run -- --help
 ## Documentation
 
 - [`AGENTS.md`](AGENTS.md): instructions for agents working in this repo.
+- [`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](docs/AGENT_TOOLS_PLATFORM_SPEC.md):
+  the platform contract — envelope, errors, mutation safety, selectors,
+  tool taxonomy, maturity ladder. Authoritative for cross-tool design.
+- [`docs/error-registry.md`](docs/error-registry.md): cross-tool error
+  code registry.
 - [`docs/tooli.md`](docs/tooli.md): concise guide for building Python CLIs with
   `tooli`.
 - [`docs/skills.md`](docs/skills.md): skill authoring guide and local skills

--- a/docs/AGENT_TOOLS_PLATFORM_SPEC.md
+++ b/docs/AGENT_TOOLS_PLATFORM_SPEC.md
@@ -1,0 +1,915 @@
+# Agent Tools Platform Specification
+
+> Status: living spec, v0.1 (initial draft).
+> Audience: AI coding agents, human maintainers, and technical decision-makers
+> who need to understand `agent_tools` as a single platform rather than a
+> collection of unrelated CLIs.
+> Scope: this document defines the *contract* every `*li` tool in this repo
+> should converge toward. It does not redefine any tool's existing
+> behavior; existing tool specs (`tools/<name>/...`) remain authoritative for
+> their specific surfaces.
+
+This spec distinguishes carefully between four levels of certainty:
+
+| Marker | Meaning |
+|---|---|
+| **Implemented** | Behavior already shipped in at least one tool, with tests. |
+| **Partial** | Behavior shipped in some tools but not yet uniform across the platform. |
+| **Planned** | Behavior identified in a tool spec or roadmap but not yet implemented. |
+| **Recommended** | Platform standard proposed by this spec; not yet enforced. |
+
+When in doubt, prefer "Recommended" over claiming a behavior is universal.
+
+---
+
+## 1. Purpose
+
+`agent_tools` exists because AI agents are powerful general reasoners but
+unreliable when forced to manipulate human-oriented business artifacts directly.
+LLMs can write a `.docx` byte string, edit a Markdown table by line number, or
+hand-craft an Excel formula — but they do these things slowly, expensively, and
+with a meaningful failure rate. The artifacts then have to be repaired by a
+human, and the agent's earlier reasoning is wasted.
+
+The platform answers that with a different stance:
+
+- **AI agents need deterministic tool surfaces, not brittle manual editing.**
+  Every artifact operation — "ensure this section exists", "update this row by
+  key", "add this slide from this layout" — should be a single command with
+  validated inputs, structured outputs, and a defined failure mode.
+- **Human artifacts need machine-addressable command layers.** Word documents,
+  spreadsheets, decks, knowledge bases, Jira issues, Notion pages, clipboards,
+  and shells were not designed to be addressed programmatically by an outside
+  agent. The `*li` tools impose a stable address space (stable IDs, A1 ranges,
+  slide/shape paths, vault IDs, ticket keys) on top of those artifacts.
+- **CLIs are the durable base layer.** They are low-latency, scriptable,
+  inspectable, composable, easy for an agent to call, easy for a human to
+  rehearse, and easy to embed in CI. MCP servers, Python APIs, and HTTP
+  bridges can be generated *from* the CLI surface. The CLI contract is the
+  source of truth.
+- **Skills teach agents *when* to call the tools.** The CLI defines the *what*
+  and the *how*; skills (see `docs/skills.md`) define the *when* and bind
+  agent intent to deterministic command sequences.
+
+The platform is, in shape, a Unix toolbox for agents working in real business
+artifacts: many small, sharp tools, one shared contract, predictable
+composition.
+
+---
+
+## 2. Platform Thesis
+
+`agent_tools` is:
+
+- **Agent-native, not merely human-friendly.** Default output is structured.
+  Default error responses are machine-recoverable. Caller detection
+  (`TOOLI_CALLER`) lets a tool adapt to humans, agents, or CI without forking
+  command surfaces.
+- **Artifact-aware, not just file-manipulating.** Tools understand the
+  structure of the artifacts they touch (sections, runs, slides, ranges,
+  vault records, issues, blocks). Plain text is a fallback, never the
+  primary interface.
+- **JSON-first, not prose-first.** Non-interactive callers get JSON;
+  interactive humans get rich text. Diagnostics never contaminate stdout in
+  JSON mode.
+- **Plan-first for mutation.** Mutating commands either default to a dry-run
+  plan (e.g. `mdli`, `notionli`, `framerli`) or expose `--dry-run` as a
+  first-class flag. An agent can always rehearse a destructive operation
+  before committing to it.
+- **Composable like Unix tools, but safer and more typed.** Stdin and stdout
+  are NDJSON or JSON envelopes; piping `vaultli search` into `xli batch` is
+  a normal workflow, not a hack.
+- **Built for skills, scripts, CI, and autonomous agent loops.** Every tool
+  should be usable by any one of those callers without translation.
+
+> **Operating thesis.** Every tool should turn an ambiguous human artifact
+> operation into an explicit, validated, inspectable command. If the agent
+> cannot describe what will change before it changes, the tool is not yet
+> agent-ready.
+
+---
+
+## 3. Design Principles
+
+These are the principles every `*li` tool should follow. Existing tools
+already match many of them; the gaps are this platform's harmonization
+backlog.
+
+1. **Explicit inputs.** No magic environment scraping for required values.
+   Required arguments are required; optional ones have documented defaults.
+2. **Structured outputs.** A tool's stdout in JSON mode is parseable without
+   regex by any agent that knows the envelope. Never mix prose and data on
+   stdout.
+3. **Stable selectors.** Where the artifact has stable identifiers (a Jira
+   key, an mdli stable ID, a Notion page ID, an A1 range, a named table, a
+   vault ID), prefer them. Path/title selectors are bootstrap-only.
+4. **Idempotency by default.** Re-running an `ensure`, `upsert`, or `apply`
+   command against an unchanged artifact must produce zero diff.
+   `--idempotency-key` is the platform-recommended escape hatch for retry
+   safety on systems that lack inherent idempotency.
+5. **Dry-run before mutation.** Mutating commands either default to a plan
+   (preferred) or expose `--dry-run` (acceptable). Either way, the agent can
+   inspect the planned change without touching the artifact.
+6. **Atomic writes where the artifact allows it.** Build a shadow artifact
+   and rename into place; never partially overwrite a file an agent or
+   human is reading. `xli` and `docli` formalize this; `mdli` follows the
+   same model with `--write` plus preimage hashes.
+7. **Fingerprint / preimage protection for concurrent edits.** Mutating
+   commands should accept a preimage hash and refuse the write if the
+   on-disk bytes have changed since the agent inspected them.
+   (`mdli --preimage-hash`, `xli` fingerprint compare-and-swap.)
+8. **Predictable errors with recovery suggestions.** Every error has a
+   stable code, a category, a human message, machine-readable details, a
+   suggested next action, and a retryability indicator. See §5.
+9. **Clean stdout in JSON mode.** Diagnostics, logs, and progress go to
+   stderr. JSON parsers must never see them.
+10. **Human-readable mode is secondary.** Rich text output is welcome but
+    must never be the only output mode for an operation an agent might call.
+11. **Small composable commands over monolithic agents.** A tool exposes
+    primitives an agent can reason over (`ensure`, `replace`, `upsert`,
+    `assign`, `apply-plan`), not high-level chat verbs.
+12. **Source files remain the source of truth.** Generated indexes,
+    sidecars, audit logs, and cache files are rebuildable. `vaultli`
+    formalizes this: `INDEX.jsonl` is a derived cache, the files on disk
+    are canonical.
+13. **Generated regions are fenced and protected.** When a tool writes into
+    a human-edited artifact, it should mark the generated region (mdli
+    managed blocks, docli tracked changes, xli table ranges) so future runs
+    do not silently clobber human edits.
+14. **Rust for fast deterministic cores; Python where ecosystem depth
+    matters.** Both are first-class. Language choice is downstream of the
+    contract.
+15. **No hidden magic when agents need traceability.** State changes go to
+    audit logs (`framerli`/`notionli` patterns). Every mutation should be
+    reconstructible from the JSON envelope plus the artifact bytes.
+
+---
+
+## 4. Canonical Command Contract
+
+This section defines the *recommended* shape every tool should converge
+toward. Many existing tools deviate (see §4.6). Convergence is a roadmap
+item, not a rewrite mandate.
+
+### 4.1 Naming
+
+- Binaries are named `<domain>li` (`xli`, `mdli`, `vaultli`, ...) — short,
+  agent-typeable, autocompletes well, makes the family visible in shell
+  history. **Implemented.**
+- Subcommands group by noun, then verb: `xli sheet add`, `mdli section
+  ensure`, `notionli row upsert`. **Recommended; followed by most tools.**
+- Verbs are drawn from a small shared vocabulary:
+
+  | Verb | Meaning |
+  |---|---|
+  | `inspect` | Read structural metadata; never mutates. |
+  | `read` / `get` / `show` | Read content by selector. |
+  | `list` | Enumerate items, paginated. |
+  | `ensure` | Create if missing; leave alone if present (idempotent). |
+  | `replace` | Replace the addressed content unconditionally. |
+  | `upsert` | Insert or update by key (idempotent on key). |
+  | `delete` / `remove` / `rm` | Remove an addressed item. |
+  | `apply` | Execute a recipe / plan against an artifact. |
+  | `plan` | Compute the change a recipe would make, without applying. |
+  | `apply-plan` | Apply a previously computed plan with preimage protection. |
+  | `validate` | Check artifact against a schema or invariants. |
+  | `lint` | Surface style/structural warnings without failing on minor issues. |
+  | `doctor` | Check the local environment for runtime prerequisites. |
+  | `schema` | Emit machine-readable command/result schemas. |
+  | `batch` | Apply an NDJSON stream of micro-ops in one transaction. |
+
+### 4.2 Global Flags
+
+The recommended global flag set, modeled on `tooli`'s injected flags
+(see `docs/tooli.md`) and existing `mdli`/`xli`/`framerli` patterns:
+
+| Flag | Purpose | Status |
+|---|---|---|
+| `--json` | Force JSON envelope on stdout. | Implemented across most tools. |
+| `--jsonl` | Stream NDJSON for list/long-running commands. | Partial. |
+| `--output {auto,json,jsonl,text,plain}` | Explicit output mode. | Implemented in `tooli`-based tools. |
+| `--dry-run` | Compute and emit the plan without mutating. | Implemented in many tools; default behavior in `mdli`/`notionli`/`framerli`. |
+| `--quiet` / `-q` | Suppress non-error diagnostics. | Implemented widely. |
+| `--verbose` / `-v` | Increase diagnostic verbosity. | Partial. |
+| `--force` | Override safety checks where supported. | Partial. |
+| `--no-color` | Disable color in human mode. | Partial. |
+| `--timeout <ms>` | Bound execution time. | Recommended. |
+| `--idempotency-key <key>` | Safe-retry key for non-idempotent surfaces. | Implemented in `tooli`. |
+| `--schema [--command X]` | Emit JSON Schema for inputs/outputs. | Implemented in `xli`; recommended for all. |
+| `--help-agent` | Compact agent-oriented help. | Implemented in `tooli`-based tools. |
+| `--agent-manifest` | Emit a discovery manifest (commands, capabilities, errors, examples). | Recommended, implemented in `tooli`. |
+| `--response-format {concise,detailed}` | Hint at response shape. | Recommended. |
+
+Avoid defining command-local flags that collide with these names.
+
+### 4.3 Stdin and Stdout Conventions
+
+- `-` as a positional file argument means stdin. **Implemented in `mdli`.**
+- NDJSON is the recommended batch input format; one JSON object per line,
+  each describing one micro-op. **Implemented in `xli batch` and the
+  `mdli` recipe layer.**
+- Tools that emit lists in JSONL mode emit one record per line and write
+  pagination metadata to stderr or to a final summary record only when
+  `--summary` (or equivalent) is requested. **Recommended.**
+- Errors in JSON mode are emitted as a single envelope to stdout with a
+  non-zero exit code; never split error metadata between stdout and stderr.
+  **Implemented in `mdli`, `tooli`-based tools.**
+
+### 4.4 Success Envelope (recommended target)
+
+The recommended canonical envelope:
+
+```json
+{
+  "ok": true,
+  "result": { },
+  "meta": {
+    "tool": "xli.batch",
+    "version": "0.4.2",
+    "duration_ms": 142,
+    "dry_run": false,
+    "warnings": [],
+    "annotations": { "readOnlyHint": false, "idempotentHint": true },
+    "truncated": false,
+    "next_cursor": null
+  }
+}
+```
+
+Implementations may add a `schema` field at the top level (as `mdli` does
+with `"schema": "mdli/output/v1"`) to version the envelope. Such a field
+is recommended for any tool whose envelope shape may evolve.
+
+### 4.5 Error Envelope (recommended target)
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "E3001",
+    "category": "state",
+    "message": "No section matched selector 'cashplus.analytics'.",
+    "suggestion": {
+      "action": "retry_with_modified_input",
+      "fix": "Run `mdli id list report.md` to see available IDs.",
+      "example": "mdli section get report.md --id cashplus.okr"
+    },
+    "is_retryable": true,
+    "details": { "selector": "cashplus.analytics" }
+  },
+  "meta": {
+    "tool": "mdli.section.get",
+    "version": "0.5.1",
+    "duration_ms": 9,
+    "dry_run": false,
+    "warnings": []
+  }
+}
+```
+
+The error code may be either a numeric `E1xxx`–`E5xxx` family code (the
+`tooli` convention; see `docs/tooli.md`) or a stable string code prefixed
+`E_` (the `mdli`/`framerli`/`notionli` convention). Both are acceptable
+today; see §5 for the harmonization recommendation.
+
+### 4.6 Existing Deviations (recorded, not corrected here)
+
+This is the current envelope reality, not the target. Harmonization is a
+roadmap item; rewriting envelopes mid-flight breaks downstream skills, so
+this spec records deviations rather than declaring a flag day.
+
+| Tool | Deviation from §4.4 / §4.5 |
+|---|---|
+| `mdli` | Wraps with top-level `schema: "mdli/output/v1"`; uses `result` + string error codes (`E_AMBIGUOUS_SELECTOR`). Mutating commands return an `ops`/`preimage_hash`/`postimage_hash` block. |
+| `xli` | JSON-first envelope per `tools/xli/README.md`; emits `umya-spreadsheet` warnings inline on mutating commands. |
+| `framerli` | Uses `data` instead of `result`; error fields are `hint` + `retryable` instead of `suggestion` + `is_retryable`. |
+| `docli` (spec) | Uses `data` + top-level `command` and `elapsed_ms`; error code uses `INVALID_TARGET`-style strings without `E_` prefix. |
+| `clipli` | Documents a minimal `{ok, error, code}` failure envelope; broader fields exist in practice. |
+| `deckli` (spec) | Uses `success` instead of `ok` and a per-command `command` field; error includes `suggestion` as a string. |
+| `notionli` | Implements MVP envelope with operation receipts and dry-run-by-default; converging toward §4.4. |
+| `jirali` | Stable JSON envelope with exit codes 0–8 (Jira-shaped, not `E1xxx`). |
+
+The recommendation is to add a top-level `schema` field to every tool's
+envelope so that envelope versions can evolve independently per tool while
+agents can detect the shape without sniffing.
+
+---
+
+## 5. Error Taxonomy
+
+The platform recommends a two-layer error taxonomy: a **shared family
+prefix** (so error handlers can branch generically) and an **artifact-
+specific code** (so agents can recover precisely).
+
+### 5.1 Shared Families
+
+Modeled on `tooli`'s `E1xxx`–`E5xxx` families (see `docs/tooli.md`):
+
+| Family | Meaning | Typical exit code |
+|---|---|---:|
+| `E1xxx` | Input / user error: bad flags, malformed JSON, schema violation. | 2 |
+| `E2xxx` | Auth / permission: missing token, denied scope, expired credential. | 30 |
+| `E3xxx` | State: not found, conflict, ambiguous selector, stale preimage. | 10 |
+| `E4xxx` | Runtime / external dependency: network failure, missing binary, target app unavailable. | 70 |
+| `E5xxx` | Internal / tool bug: unreachable branch, panic-recovered failure. | 70 |
+
+Existing string-coded tools (`mdli`, `framerli`, `notionli`) should
+publish a mapping from their string code to a numeric family so generic
+agent handlers can branch on `category`. **Recommended.**
+
+### 5.2 Artifact-Specific Codes
+
+These names appear across tool specs and should converge to the same
+semantics wherever they apply:
+
+| Code (recommended) | Meaning | Today |
+|---|---|---|
+| `E_AMBIGUOUS_SELECTOR` | Selector matched more than one structure. | `mdli` |
+| `E_SELECTOR_NOT_FOUND` | Selector matched zero structures. | `mdli` |
+| `E_DUPLICATE_ID` | Stable ID present more than once. | `mdli` |
+| `E_STALE_PREIMAGE` | Input bytes changed since the plan was computed. | `mdli` |
+| `E_BLOCK_LOCKED` | Generated region marked locked, edit refused. | `mdli` |
+| `E_BLOCK_MODIFIED` | Generated region content edited outside the tool. | `mdli` |
+| `E_VALIDATION_*` | Validation findings against a declared schema. | `mdli` |
+| `E_AUTH_MISSING` | No credentials configured. | `framerli`, `notionli` |
+| `E_NOT_IMPLEMENTED` | Command surface exists but bridge/backend not yet wired. | `framerli` |
+| `E_RATE_LIMITED` | Upstream rate limit hit; retry after `details.retry_after`. | Recommended. |
+| `E_PARTIAL_FIDELITY` | Operation succeeded but artifact lost some fidelity (e.g. `umya-spreadsheet` fallback). | Recommended; surfaced today as warnings in `xli`. |
+| `E_BRIDGE_DISCONNECTED` | Live-app bridge (deckli sidecar, framerli node) not connected. | Recommended. |
+| `E_SCHEMA_MISMATCH` | Recipe / job / plan version not understood. | `mdli` |
+
+Each error must carry: `code`, `category`, `message`, `details`,
+`suggestion`, `is_retryable`. Exit codes follow the family table above
+unless the artifact has its own established convention (e.g. `jirali`'s
+0–8 codes).
+
+---
+
+## 6. Mutation Safety Model
+
+This is the most important section. Every tool that mutates a real
+artifact should follow the same lifecycle.
+
+### 6.1 Lifecycle
+
+```
+inspect  →  plan  →  dry-run  →  apply  →  validate  →  diff/report
+```
+
+- **inspect** reads structural metadata so the agent knows what exists.
+- **plan** computes the intended change. For declarative recipes this is
+  an explicit command (`mdli plan`); for one-shot edits the plan is the
+  default JSON output of the mutating command.
+- **dry-run** confirms the plan against the current artifact bytes
+  without writing.
+- **apply** writes atomically.
+- **validate** checks the post-state against a schema or invariants.
+- **diff/report** explains semantically what changed. (`mdli diff` is the
+  reference implementation; see `tools/mdli/README.md`.)
+
+### 6.2 Mandatory Behaviors for Mutating Commands
+
+Mutating commands must:
+
+1. **Default to safe.** Either default to a dry-run plan (preferred for
+   high-risk artifacts: `mdli`, `notionli`, `framerli`) or require an
+   explicit `--write` / `--apply` / `--yes` flag. Never mutate by default
+   without an explicit affirmative input.
+2. **Emit a structured plan.** The plan describes ops, addresses, and
+   preimage/postimage hashes where applicable. Agents can store, diff,
+   and re-apply plans.
+3. **Use atomic writes.** Build a shadow artifact in the same filesystem;
+   fsync; rename. Never modify the source archive in place. The `docli`
+   spec formalizes three durability modes (`fast`/`durable`/`paranoid`);
+   `xli` uses atomic commits + fingerprint compare-and-swap.
+4. **Refuse on stale preimage.** If `--preimage-hash` is supplied and
+   the on-disk bytes do not match, return `E_STALE_PREIMAGE` and exit
+   non-zero.
+5. **Carry preimage and postimage hashes** in the result envelope so
+   the agent can compose subsequent operations safely.
+6. **Never silently overwrite human edits in generated regions.** The
+   `mdli` managed-block model with checksums is the reference: a
+   generated block whose checksum no longer matches its content is an
+   `E_BLOCK_MODIFIED` error, not a silent overwrite.
+7. **Record warnings when fidelity may be lost.** When an operation uses
+   a partial implementation path (e.g. `xli`'s `umya-spreadsheet`
+   fallback for chart-bearing workbooks), the envelope must carry a
+   warning the agent can surface.
+8. **Use conflict sidecars for unrecoverable conflicts.** When the tool
+   cannot resolve a three-way conflict, write a JSON sidecar (e.g.
+   `<file>.mdli.conflict`) containing recorded base, on-disk, and
+   incoming content; exit non-zero; leave the source file untouched.
+9. **Append to an audit log when configured.** `framerli`'s
+   `state/audit.ndjson` and `notionli`'s receipt log are the reference
+   patterns. Mutations should be reconstructible from the audit log
+   alone.
+10. **Allow CI to gate on validation and diff summaries.** `mdli
+    validate` and `mdli diff --summary` are the reference: structured
+    counts suitable for CI threshold checks.
+
+### 6.3 Reference Tools
+
+- `tools/mdli/README.md` — preimage hashes, managed blocks with
+  checksums, three-way conflict sidecars, semantic diff, recipe
+  plan/apply.
+- `tools/xli/README.md` — atomic commits, fingerprint compare-and-swap,
+  partial-fidelity warnings on the `umya-spreadsheet` fallback path.
+- `tools/docli/docli-spec.md` §2 — explicit `fast`/`durable`/`paranoid`
+  durability modes and the shadow-package write pipeline.
+- `tools/framerli/README.md` — dry-run-by-default mutations with audit
+  logging.
+
+---
+
+## 7. Artifact Addressing and Selectors
+
+Selectors are how an agent points at a thing inside an artifact. The
+platform principle:
+
+> **If a human can rename or reorder it, agents should not rely solely on
+> its visible name or ordinal position.**
+
+Recommended addressing model per artifact family:
+
+| Artifact | Stable selector | Bootstrap-only selector | Notes |
+|---|---|---|---|
+| Markdown sections (`mdli`) | Hidden ID marker (`mdli:id v=1 id=...`) | `--path "H1 > H2"` | Path matches are an error if ambiguous. |
+| Markdown tables (`mdli`) | Named table marker + key column | Position within section | Row addressing requires `--key`. |
+| Managed blocks (`mdli`) | Block ID with checksum | — | No fallback; blocks must be addressed by ID. |
+| Excel cells (`xli`) | A1 / `Sheet!A1:B10` | Named ranges, named tables | Address by named table when one exists. |
+| Excel sheets (`xli`) | Sheet name | Sheet index | Renames break index addressing; named addressing survives. |
+| Decks (`deckli`) | Slide ID, shape ID, placeholder type (`title`, `body`) | Slide index, shape index | Placeholder type beats positional index when present. |
+| DOCX (`docli`) | Heading path + offset, bookmark, paragraph ID | Paragraph index | The spec formalizes a selector enum with `body`/`header.default`/`footer.first` story scopes. |
+| Knowledge vault (`vaultli`) | Vault `id` | File path | `INDEX.jsonl` resolves IDs to files; never address by position. |
+| Jira (`jirali`) | Issue key (`ENG-123`) | JQL query | JQL is composition, not identity. |
+| Notion (`notionli`) | Page/block/data-source UUID | Title search | Aliases (`alias set tasks ...`) make UUIDs ergonomic. |
+| Framer (`framerli`) | Project URL + collection slug | — | Project URL is the canonical handle. |
+| Clipboard (`clipli`) | UTI (`public.html`) + named template ID | Position in clipboard history | Templates are versioned by name. |
+
+Tools that introduce stable IDs into existing artifacts (the `mdli id
+assign` pattern) should provide a one-shot bootstrap command so legacy
+files can be lifted into the stable-selector model.
+
+---
+
+## 8. Tool Family Taxonomy
+
+This is the consolidated view of every tool family in the repo today.
+Maturity uses the ladder defined in §15.
+
+| Tool | Domain | Source-of-truth model | Agent workflow | Maturity (§15) | Status |
+|---|---|---|---|---:|---|
+| `mdli` | Markdown AST: sections, tables, frontmatter, managed blocks | File on disk; managed regions fenced with checksums | Inspect → plan → apply → validate → diff | 7 | Implemented; PRD Phases 1–8 shipped. See `tools/mdli/README.md`. |
+| `xli` | Excel `.xlsx` workbooks | File on disk; fingerprint compare-and-swap | Inspect → write/format/batch → validate → recalc | 6 | Implemented MVP; partial fidelity on the `umya-spreadsheet` fallback path. See `tools/xli/README.md`. |
+| `vaultli` | File-based knowledge vault | Files on disk; `INDEX.jsonl` is a derived cache | Init → ingest/scaffold → index → validate → search | 6 | Implemented (Rust + Python parity). See `tools/vaultli/README.md`. |
+| `clipli` | macOS clipboard (HTML/RTF/SVG/PNG/PDF), reusable templates | Pasteboard + on-disk template store with versioning | Capture → templatize → render → paste | 5 | Implemented for macOS; spec at `tools/clipli/CLIPLI_SPEC.md`. |
+| `jirali` | Atlassian Jira | Live REST/GraphQL + local deterministic state for rehearsal | Auth → JQL/issue/sprint/comment ops with structured exit codes | 5 | Implemented for issue/comment core; broader surfaces deterministic-stub. |
+| `notionli` | Notion workspace | Live API + local profile state, dry-run-by-default writes | Search → resolve → row/page/db ops with `--apply` to commit | 4 | MVP implemented; expanding. See `tools/notionli/README.md`. |
+| `framerli` | Framer Server API (sites/CMS/publish) | Live API via Node bridge + local audit log | Auth → inspect → plan → publish with approval gates | 4 | Implemented core slice with mock bridge; broader surface returns `E_NOT_IMPLEMENTED`. |
+| `deckli` | PowerPoint via Office.js bridge | Live document inside running PowerPoint, addressed via WebSocket sidecar | Inspect masters/theme → batch edits → render → verify | 1 (spec); proto in `addin/`, `bridge/` | Spec at `tools/deckli/DECKLI_SPECS.md`; live-bridge architecture distinct from file-mutation tools. |
+| `docli` | Word `.docx` | File on disk; shadow-package atomic commit pipeline | Inspect → narrow edit verbs → review → finalize → diff | 0–1 (spec) | Spec at `tools/docli/docli-spec.md`; workspace crates scaffolded. |
+| `vizli` | Parameterized visualization templates → SVG/PNG/HTML/PDF | Sidecar `.md` files describe templates; render is deterministic | Search sidecars → resolve params → render → verify | 1–2 (Python, in development) | Spec at `tools/vizli/VIZLI_README.md` and `tools/vizli/PLAN.md`. |
+| `bashli` | Shell workflow execution | JSON TaskSpec → structured StepResult; bash is read-only substrate | Compose TaskSpec → execute → consume structured output | 0–1 (spec) | Spec at `tools/bashli/bashli-spec-final.md`; greenfield. |
+| `barli` | macOS menu bar plugin host | Local YAML config + Python plugins; hot-reloads | Drop plugin → configure menu → click | 3 (working app, no test suite) | See `tools/barli/README.md`. Companion to the platform, not an artifact tool. |
+| `pdfli` | PDF inspection/extraction/conversion/repair | Planned | Planned | 0 | Placeholder. See `docs/tool-roadmap.md`. |
+| `gitli` | GitHub issues, labels, wiki, PRs, repo workflows | Planned | Planned | 0 | Placeholder. See `docs/tool-roadmap.md`. |
+
+Cross-tool relationships:
+
+- `vaultli` is the recommended **knowledge substrate**. Every other tool
+  can pull queries, templates, runbooks, and prompts from a vault rather
+  than embedding them.
+- `mdli` is the recommended **report surface**. Tools that produce
+  textual artifacts should emit Markdown that `mdli` can manage
+  (sections, named tables, managed blocks).
+- `xli` and `vizli` are the recommended **analytics surface**. Numeric
+  analysis lives in workbooks; visualizations are deterministic templates.
+- `clipli` is the recommended **handoff surface** to GUI apps that lack
+  CLIs (Excel, PowerPoint, browsers) on macOS.
+- `deckli` is the live-document complement to `docli` and `xli`: it
+  manipulates a running app rather than a file on disk.
+
+---
+
+## 9. Cross-Tool Workflow Patterns
+
+These are the canonical compositions the platform is built to support.
+Each is a recommended pattern, not a hard-coded pipeline.
+
+### 9.1 Knowledge → Artifact
+
+```text
+vaultli search "Q3 revenue runbook"
+  → mdli context vault://docs/runbook --max-tokens 2000
+    → docli edit insert / mdli section ensure
+      → xli create --from-csv / vizli render
+        → mdli validate report.md --schema report.schema.yml
+```
+
+The agent never hand-writes a report; it composes from indexed
+knowledge, drops content into addressable artifacts, and validates the
+result.
+
+### 9.2 Analytics Report Generation
+
+```text
+vaultli show queries/retention.sql
+  → run query → NDJSON rows
+    → xli create report.xlsx --from-csv ... + xli format
+      → vizli render charts/line_timeseries --data rows.csv
+        → mdli table replace report.md --name retention --from-rows rows.ndjson
+          → mdli apply report.md --recipe report.yml
+            → mdli validate + mdli diff against last week
+```
+
+This is the workflow `mdli` was specifically designed for; see
+`tools/mdli/README.md` "Recipe / Apply Flow".
+
+### 9.3 Clipboard-Mediated Workflow
+
+```text
+clipli inspect → identify rich format (HTML, SVG)
+  → clipli capture --templatize
+    → agent fills variables
+      → clipli paste / clipli excel data.csv --copy-as svg
+        → user pastes into Excel/PowerPoint
+```
+
+This is the bridge between deterministic tools and GUI apps the
+platform does not (yet) drive directly.
+
+### 9.4 Live Deck Workflow
+
+```text
+deckli inspect --masters → discover layouts
+  → deckli inspect --theme → discover colors
+    → deckli batch ops.json → apply edits in one round trip
+      → deckli render --slide N → base64 PNG
+        → vision verification
+          → corrective deckli batch
+```
+
+The vision-feedback loop is what makes a live-document bridge worth
+the architectural complexity of the sidecar.
+
+### 9.5 Markdown as Control Plane
+
+`mdli` recipes, validation schemas, and templates can be checked into
+git and used as the deterministic control plane for what a report
+*should* contain. CI runs `mdli apply` and `mdli validate` on every PR.
+
+### 9.6 Agent Skill Workflow
+
+```text
+skill frontmatter triggers → SKILL.md instructions
+  → preflight check (doctor) → deterministic CLI calls
+    → quality gate (validate/lint) → done
+```
+
+Skills should not contain prose that the CLI could enforce. If a step
+matters, write it as a script or a `validate` command, not as a
+paragraph in `SKILL.md`.
+
+---
+
+## 10. Skills and Progressive Disclosure
+
+Skills (see `docs/skills.md`) are how agents learn *when* to use these
+tools. The platform recommendations:
+
+- **One skill per mature tool, eventually.** Today: `mdli/SKILL.md`,
+  `vaultli/SKILL.md`, `clipli/clipli/SKILL.md`, `deckli/SKILL.md`,
+  `jirali/SKILL.md`. Recommended additions: `xli`, `notionli`,
+  `framerli` once their command surfaces stabilize.
+- **`SKILL.md` stays concise.** Long references go into `references/`
+  alongside the skill. Critical determinism goes into scripts, not
+  prose. The guidance in `docs/skills.md` is authoritative.
+- **Skills should include preflight checks, workflows, failure
+  recovery, and quality gates.** The `mdli` SKILL is the reference: it
+  documents exit codes, error codes, recommended workflows, and
+  recovery patterns.
+- **Trigger design matters.** Descriptions should combine domain
+  vocabulary (what the tool does) with user phrasing (what the user
+  says). See `docs/skills.md` for testing approach.
+- **Skills should not duplicate CLI behavior.** If the `apply` command
+  validates and writes atomically, the skill should call `apply`, not
+  re-implement validation in prose.
+- **Cross-tool skills are valuable.** A "generate quarterly report"
+  skill could legitimately span `vaultli`, `xli`, `vizli`, and `mdli`.
+  Such skills are the right place for the *composition* glue that no
+  individual tool owns.
+
+---
+
+## 11. Schema, Manifest, and Discovery Standards
+
+Agents need to discover capabilities without prior knowledge. The
+platform's discovery surface, in order of precedence:
+
+1. **`--schema`** emits machine-readable command and result schemas.
+   Recommended forms (already in `xli`):
+   - `xli schema` — full schema
+   - `xli schema --command create` — single-command schema
+   - `xli schema --result FormatOutput` — single-result schema
+2. **`--agent-manifest`** emits a discovery manifest containing every
+   command, its capabilities, error codes, examples, annotations
+   (`readOnlyHint`, `idempotentHint`, `destructiveHint`,
+   `openWorldHint`), and pagination hints. **Implemented in `tooli`;
+   recommended for all tools.**
+3. **`--help-agent`** is a compact, low-token, agent-oriented
+   alternative to `--help`. **Implemented in `tooli`; recommended.**
+4. **Output annotations** in the envelope's `meta.annotations` block
+   tell the agent what guarantees the command makes
+   (read-only, idempotent, destructive, open-world).
+5. **MCP bridge** is a generated projection of the same contract.
+   `tooli` apps can serve MCP via `mcp serve`; standalone Rust binaries
+   can wrap themselves with `tooli serve` or a thin MCP shim. The CLI
+   remains canonical; MCP is a transport.
+
+> The CLI is the canonical interface. Generated schemas, Python APIs,
+> and MCP surfaces are projections of the same contract. If a behavior
+> is not on the CLI, it is not part of the platform contract.
+
+---
+
+## 12. Testing and Fixture Standards
+
+Testing patterns the platform expects, in rough priority order:
+
+| Test type | Purpose | Reference |
+|---|---|---|
+| Direct function tests | Confirm core logic without CLI overhead. | All Rust tools' `*_tests.rs`. |
+| CLI contract tests | Confirm flags, exit codes, and envelope shape. | `mdli` `cli_contract` tests; `tooli`'s `TooliTestClient`. |
+| JSON envelope tests | Lock `ok`/`error`/`meta` shape per tool. | `mdli`, `xli`. |
+| Dry-run tests | Confirm no mutation occurs and the plan is faithful. | `mdli`, `notionli`. |
+| Idempotency tests | Confirm a second apply produces zero diff. | `mdli` apply / apply-plan. |
+| Mutation safety tests | Atomic write, fingerprint, conflict sidecar. | `mdli` three-way conflict; `xli` fingerprint. |
+| Stale-preimage tests | Confirm refusal on changed input bytes. | `mdli`. |
+| Malformed input tests | Confirm clear errors on bad NDJSON, bad YAML, bad selectors. | `mdli` fixture corpus. |
+| Edge-case fixture corpus | Real-world artifact pathologies. | `tools/mdli/tests/fixtures/`. |
+| Parity tests (Rust ↔ Python) | When a tool ships in two languages. | `vaultli` Rust/Python parity. |
+| Golden output tests | Lock stable JSON shapes; lock rendered SVG/PNG. | `vizli` golden testing per `PLAN.md`. |
+| Integration tests | End-to-end workflows across tools. | `jirali` mock-Jira integration. |
+
+**Recommended bar before a tool is "agent-ready":**
+
+1. Three realistic agent scenarios documented and tested.
+2. One failure / recovery scenario tested (what does the agent do when
+   the artifact is in an unexpected state?).
+3. One dry-run / apply scenario tested (if the tool mutates).
+4. A schema or contract document the agent can consume.
+5. A SKILL.md that triggers correctly and points at the CLI.
+
+---
+
+## 13. Implementation Language Strategy
+
+The repo's apparent pattern, and the recommendation:
+
+- **Rust** for fast, deterministic, low-latency CLI cores — especially
+  artifact mutation. Rust's sub-millisecond cold start is what makes
+  per-edit atomic commits practical (the `docli` thesis). Used by
+  `mdli`, `xli`, `clipli`, `jirali`, `notionli`, `framerli`, `deckli`,
+  `docli`, `bashli`, the `vaultli` primary implementation.
+- **Python** for ecosystem-heavy validation, dataframes, rendering,
+  reconciliation, and reference implementations. Used by
+  `xli-companion`, `vaultli/py/core.py`, `vizli`, `barli`. Built with
+  `tooli` (`docs/tooli.md`) so Python tools share envelope, error,
+  schema, and MCP behavior with each other.
+- **TypeScript / JavaScript** when the target platform requires it —
+  Office.js add-ins (`deckli/addin/`), Node SDK bridges
+  (`framerli/bridge/`, the `deckli` sidecar). Treated as sidecars,
+  never as the primary command surface.
+- **Sidecars are acceptable** when the target platform requires them
+  (Office add-ins, vendor SDKs available only in JS). The platform
+  contract is the JSON the sidecar exchanges with the Rust/Python core,
+  not the language of the sidecar.
+
+Language choice is downstream of the agent contract. If a tool exposes
+the right envelope, the right errors, and the right safety model, its
+implementation language is an engineering detail.
+
+---
+
+## 14. Documentation Standards
+
+Documentation should land in predictable places:
+
+| Where | What |
+|---|---|
+| `README.md` | Repo overview, featured tools, common envelope, status. |
+| `AGENTS.md` / `CLAUDE.md` | Short instructions for agents working *in this repo*. |
+| `docs/AGENT_TOOLS_PLATFORM_SPEC.md` | This file: the platform contract. |
+| `docs/tooli.md` | Python CLI framework guide. |
+| `docs/skills.md` | Skill authoring guide; local skills inventory. |
+| `docs/tool-roadmap.md` | Tool inventory, status, planned tools. |
+| `docs/RUST_CRATES_FOR_TOOLS.md` | Crate selection notes for Rust tools. |
+| `tools/<tool>/README.md` | Operator-facing summary. |
+| `tools/<tool>/<tool>-spec.md` (or `*_SPEC*.md`, `*_PRD*.md`) | Developer spec. |
+| `tools/<tool>/SKILL.md` | Agent-facing operating guide. |
+| `tools/<tool>/PLAN.md` | Implementation plan / phase milestones. |
+| `tooli_feedback.md` | Agent-tool feedback, friction logs, missing capabilities. |
+
+Each tool's documentation should distinguish at least four registers:
+
+1. **Operator quickstart** — copy-pasteable commands.
+2. **Agent workflow guide** — recommended sequences and recovery paths.
+3. **Developer spec** — internals, invariants, parity matrix.
+4. **Roadmap** — what is partial vs. planned.
+
+Generated documentation should be marked as such (e.g. emit
+`<!-- generated by tool X -->` markers) so humans and agents know not
+to hand-edit.
+
+---
+
+## 15. Maturity Ladder
+
+A common ladder so the roadmap can be discussed in shared terms.
+Classifications below are conservative best-effort; correct in place
+when better evidence exists.
+
+| Level | Name | Definition |
+|---:|---|---|
+| 0 | Idea / spec only | A README or PRD exists; no code. |
+| 1 | Prototype command | A binary exists with at least one working subcommand. |
+| 2 | JSON contract implemented | All commands emit a stable JSON envelope. |
+| 3 | Dry-run and validation implemented | Mutations are rehearsable; validation surfaces structural issues. |
+| 4 | Atomic mutation and conflict safety implemented | Atomic writes, fingerprint protection, conflict handling. |
+| 5 | Skill and agent workflow documented | A `SKILL.md` exists and has been exercised. |
+| 6 | Fixture-backed contract tests | Realistic artifact pathologies are covered by tests. |
+| 7 | Cross-tool integration tested | Composes correctly with at least one other `*li` tool. |
+| 8 | Stable platform-ready tool | Versioned envelope, complete error registry, durable docs, real users. |
+
+Best-effort current placement (correct in `docs/tool-roadmap.md` when
+better evidence emerges):
+
+| Tool | Estimated level |
+|---|---:|
+| `mdli` | 7 |
+| `xli` | 6 |
+| `vaultli` | 6 |
+| `clipli` | 5 |
+| `jirali` | 5 |
+| `notionli` | 4 |
+| `framerli` | 4 |
+| `barli` | 3 (no tests) |
+| `vizli` | 1–2 |
+| `deckli` | 1 (proto) |
+| `docli` | 0–1 (spec, scaffolded) |
+| `bashli` | 0–1 (spec) |
+| `pdfli`, `gitli` | 0 |
+
+Tools at level 6+ should be safe defaults for new agent workflows.
+Tools at level ≤2 should not be wired into autonomous loops without
+human review.
+
+---
+
+## 16. Open Questions
+
+Real, unresolved decisions that this spec deliberately does not
+foreclose:
+
+1. **One global envelope version, or per-tool envelope versions?**
+   `mdli` uses `mdli/output/v1`; recommendation is per-tool versions
+   with a shared shape so each tool can evolve independently. Confirm.
+2. **Numeric `E1xxx` codes vs. string `E_*` codes?** Both exist today.
+   Recommendation is to keep both but require every tool to expose a
+   `category` field so generic handlers can branch.
+3. **Should `--dry-run` be universal, or should "default to plan" be
+   the universal pattern?** `mdli`/`notionli`/`framerli` default to
+   plan; `xli` accepts `--dry-run`. Decide whether the platform
+   prefers explicit-write or implicit-plan as the default.
+4. **Should every tool expose MCP?** `tooli`-based Python tools get
+   MCP for free. Rust tools currently do not. A thin shared MCP shim
+   would let any Rust tool serve MCP without per-tool effort.
+5. **How standardized should schema discovery be?** `xli` has
+   `schema --command X --result Y`. Should every tool implement the
+   same flag shape? Probably yes.
+6. **Should `plan` / `apply-plan` be universal verbs?** `mdli` and
+   `notionli` use them. `xli batch` is morally the same thing under a
+   different name. Harmonization candidate.
+7. **How are partial-fidelity warnings standardized?** `xli` emits
+   `umya-spreadsheet` fallback warnings inline; the platform should
+   define a recommended `meta.warnings[]` schema.
+8. **Should there be a top-level orchestrator CLI** (`agentli` /
+   `tooli run`) that knows about every `*li` and can route by
+   intent? Possible; not currently scoped.
+9. **How does `vaultli` become the knowledge substrate for every
+   other tool?** Open question whether tools should accept `vault://`
+   URIs natively (the `docli` spec proposes `kb://`) or whether the
+   composition stays at the skill layer.
+10. **How are credentials standardized?** Today, each tool defines its
+    own (`NOTION_API_KEY`, `JIRALI_API_TOKEN`, `FRAMER_API_KEY`,
+    Keychain support). A shared `agent_tools` credential layer would
+    reduce friction.
+11. **How is audit logging standardized?** `framerli`'s
+    `state/audit.ndjson` and `notionli`'s receipt log are
+    near-identical conceptually. Harmonization candidate.
+12. **Should the platform define a shared cancellation/timeout
+    contract?** `tooli --timeout` exists; Rust tools handle this
+    individually.
+
+---
+
+## 17. Acceptance Criteria for This Spec
+
+This document is successful when:
+
+- A new agent dropped into the repo can read this file plus
+  `AGENTS.md` and know how every `*li` tool *should* behave, even if
+  it has not yet read that tool's individual docs.
+- A developer adding a new tool family (`pdfli`, `gitli`, or any
+  future addition) can use this spec as the design checklist.
+- A maintainer reviewing a PR can cite this spec to ask: "what
+  selector model does this use?", "what is the dry-run path?",
+  "where is the error-code registry?".
+- The platform can have an honest conversation about which tools are
+  level 7 and which are level 1, without overclaiming.
+- Implementations diverge from this spec only deliberately, with a
+  recorded reason in the relevant tool spec.
+
+This document is *not* successful if it becomes a marketing brochure,
+hides current deviations, or describes capabilities the repo does not
+have. When that happens, prefer correcting this file over
+overstating reality.
+
+---
+
+## Appendix A — Existing Envelope Shapes (current reality)
+
+For agents wiring up parsers today, here are the shapes actually in
+use. These are the inputs to harmonization, not the targets.
+
+```jsonc
+// mdli — every command
+{
+  "schema": "mdli/output/v1",
+  "ok": true,
+  "result": { /* command-specific */ }
+}
+
+// mdli — mutating commands return additionally:
+{
+  "changed": true,
+  "preimage_hash": "sha256:...",
+  "postimage_hash": "sha256:...",
+  "ops": [ { "op": "ensure_section", "id": "...", "level": 2 } ],
+  "warnings": []
+}
+
+// framerli — success
+{ "ok": true, "data": {}, "meta": { "ms": 12, "profile": "default", "dry_run": false } }
+
+// framerli — error
+{ "ok": false, "error": { "code": "E_AUTH_MISSING", "message": "...", "hint": "...", "retryable": false }, "meta": {} }
+
+// docli (spec) — success
+{ "ok": true, "command": "inspect", "data": { /* ... */ }, "warnings": [], "elapsed_ms": 142 }
+
+// deckli (spec) — success
+{ "success": true, "command": "set.text", "result": { /* ... */ }, "timing_ms": 47 }
+
+// clipli — minimal failure
+{ "ok": false, "error": "message", "code": "ERROR_CODE" }
+
+// tooli (recommended target — see docs/tooli.md) — success
+{
+  "ok": true,
+  "result": { /* ... */ },
+  "meta": {
+    "tool": "app.command", "version": "1.0.0", "duration_ms": 42,
+    "dry_run": false, "warnings": [], "annotations": { "readOnlyHint": true },
+    "truncated": false, "next_cursor": null
+  }
+}
+```
+
+## Appendix B — Recommended New-Tool Checklist
+
+Before merging a new `*li` tool family:
+
+- [ ] Binary name follows `<domain>li` convention.
+- [ ] Subcommands use the verb vocabulary in §4.1 where applicable.
+- [ ] Global flags from §4.2 do not conflict with command-local flags.
+- [ ] Every command emits a stable JSON envelope (success and error).
+- [ ] Every error has `code`, `category`, `message`, `details`,
+      `suggestion`, `is_retryable`.
+- [ ] Mutating commands either default to a plan or require an
+      explicit `--write`/`--apply`/`--yes` flag.
+- [ ] Mutating commands write atomically.
+- [ ] Mutating commands accept a preimage hash where the artifact has
+      a stable byte form.
+- [ ] Selectors prefer stable IDs over names/positions.
+- [ ] `--schema`, `--agent-manifest`, `--help-agent` are present
+      (or noted as planned).
+- [ ] `tools/<tool>/README.md` exists with operator quickstart.
+- [ ] `tools/<tool>/<tool>-spec.md` (or PRD) exists for developers.
+- [ ] At least three realistic agent scenarios are tested.
+- [ ] At least one failure-recovery scenario is tested.
+- [ ] If mutating: at least one dry-run/apply scenario is tested.
+- [ ] `SKILL.md` is drafted (can be terse) once the surface stabilizes.
+- [ ] `docs/tool-roadmap.md` is updated with status.
+- [ ] If the tool deviates from this spec, the deviation is recorded
+      in the tool's spec with a reason.

--- a/docs/error-registry.md
+++ b/docs/error-registry.md
@@ -1,0 +1,237 @@
+# Cross-Tool Error Registry
+
+> Status: living registry, v0.1.
+> Authoritative platform contract:
+> [`AGENT_TOOLS_PLATFORM_SPEC.md`](AGENT_TOOLS_PLATFORM_SPEC.md) (§5).
+> Scope: shared error codes, families, and their per-tool aliases. The
+> goal is for an agent error handler written once to behave reasonably
+> across every `*li` tool.
+
+This registry catalogues:
+
+1. The five **error families** every tool should expose via `category`.
+2. The shared **artifact-specific codes** with stable semantics.
+3. **Per-tool deviations**: codes a tool emits today that should map
+   to a shared code at the next compatible bump.
+
+When a tool needs an error code that is not in the registry, propose a
+new code in this file before shipping it. Renames and deprecations are
+handled the same way: update this file first.
+
+---
+
+## 1. Error Families
+
+Modeled on `tooli`'s `E1xxx`–`E5xxx` families (see
+[`tooli.md`](tooli.md)). Every error must carry a `category` that
+maps to one of these families so generic handlers can branch without
+parsing the code.
+
+| Family | `category` | Meaning | Default exit code |
+|---|---|---|---:|
+| `E1xxx` | `input` | Bad flags, malformed JSON, schema violation, ambiguous selector that the *caller* can disambiguate. | 2 |
+| `E2xxx` | `auth` | Missing token, denied scope, expired credential. | 30 |
+| `E3xxx` | `state` | Not found, conflict, stale preimage, ambiguous selector against *artifact* state. | 10 |
+| `E4xxx` | `runtime` | Network failure, missing binary, target app/bridge unavailable, rate limit. | 70 |
+| `E5xxx` | `internal` | Tool bug, unreachable branch, panic-recovered failure. | 70 |
+
+Per-tool exit-code conventions (e.g. `jirali`'s 0–8 codes; `mdli`'s
+0–4 + 64) override the defaults above. Always check the tool's README
+for its exit-code table.
+
+---
+
+## 2. Shared Artifact Codes
+
+These codes have the same meaning everywhere they appear. New tools
+should adopt them by name; old tools should map their existing codes
+to these by the next compatible bump.
+
+### 2.1 Selector / addressing (family `E1xxx` or `E3xxx`)
+
+| Code | Family | Meaning | `is_retryable` | First/canonical use |
+|---|---|---|---|---|
+| `E_AMBIGUOUS_SELECTOR` | `input` | Selector matched more than one structure. `details.matches` lists candidates so an agent can disambiguate. | true (with a refined selector) | `mdli` |
+| `E_SELECTOR_NOT_FOUND` | `state` | Selector matched zero structures. | true (with a different selector) | `mdli` |
+| `E_DUPLICATE_ID` | `state` | Stable ID present more than once in the artifact. | false (artifact must be repaired first) | `mdli` |
+| `E_INVALID_SELECTOR` | `input` | Selector is syntactically invalid (e.g. malformed A1, malformed UUID). | true (after correction) | Recommended. |
+
+### 2.2 Mutation safety (family `E3xxx`)
+
+| Code | Meaning | `is_retryable` | First/canonical use |
+|---|---|---|---|
+| `E_STALE_PREIMAGE` | Input bytes changed since the plan was computed; refuse to write. | true (re-inspect, re-plan) | `mdli` |
+| `E_BLOCK_LOCKED` | Generated region is marked locked; edit refused unless `--force-locked`. | false (operator decision) | `mdli` |
+| `E_BLOCK_MODIFIED` | Generated region was edited outside the tool; managed checksum no longer matches. | false (resolve via three-way conflict) | `mdli` |
+| `E_CONFLICT` | Generic concurrent-edit conflict; sidecar may have been written. | true (after manual reconciliation) | Recommended. |
+
+### 2.3 Validation (family `E1xxx`)
+
+| Code | Meaning | First/canonical use |
+|---|---|---|
+| `E_VALIDATION_MISSING_SECTION` | Required section absent from the artifact. | `mdli` |
+| `E_VALIDATION_MISSING_TABLE` | Required named table absent. | `mdli` |
+| `E_VALIDATION_TABLE_COLUMNS` | Table columns differ from schema. | `mdli` |
+| `E_VALIDATION_TABLE_KEY` | Table key differs from schema. | `mdli` |
+| `E_VALIDATION_MISSING_BLOCK` | Required managed block absent. | `mdli` |
+| `E_VALIDATION_BLOCK_LOCK` | Managed block lock state differs from schema. | `mdli` |
+| `E_VALIDATION_SCHEMA_INVALID` | Validation schema itself is missing or wrong version. | `mdli` |
+| `E_SCHEMA_MISMATCH` | Recipe / job / plan version not understood by this tool version. | `mdli` |
+
+### 2.4 Auth and external dependencies (family `E2xxx` / `E4xxx`)
+
+| Code | Family | Meaning | `is_retryable` | First/canonical use |
+|---|---|---|---|---|
+| `E_AUTH_MISSING` | `auth` | No credentials configured. | false (operator must configure) | `framerli`, `notionli` |
+| `E_AUTH_INVALID` | `auth` | Credentials present but rejected by upstream. | false (operator must rotate) | Recommended. |
+| `E_AUTH_SCOPE` | `auth` | Token valid but lacks the required scope/permission. | false | Recommended. |
+| `E_RATE_LIMITED` | `runtime` | Upstream rate limit hit; `details.retry_after_ms` set when known. | true (after backoff) | Recommended. |
+| `E_BRIDGE_DISCONNECTED` | `runtime` | Live-app bridge not connected (e.g. PowerPoint add-in offline, Node sidecar down). | true (after the operator brings the bridge up) | Recommended. Today: `deckli` `no_addin`, `framerli` partial. |
+| `E_NOT_IMPLEMENTED` | `runtime` | Command surface exists but backend/bridge for it is not yet wired. | false | `framerli` |
+| `E_TIMEOUT` | `runtime` | Operation exceeded `--timeout`. | true | Recommended. |
+
+### 2.5 Artifact fidelity (family `E4xxx`)
+
+| Code | Meaning | `is_retryable` | First/canonical use |
+|---|---|---|---|
+| `E_PARTIAL_FIDELITY` | Operation succeeded but some artifact features may not have round-tripped (e.g. `xli`'s `umya-spreadsheet` fallback path on chart-bearing workbooks). Surfaced today as `meta.warnings`; promotion to a structured code is recommended. | n/a (operation already succeeded) | Recommended; today emitted as warnings by `xli`. |
+| `E_INVALID_UTF8` | Input bytes are not valid UTF-8. | true (after re-encoding) | `mdli` |
+
+---
+
+## 3. Per-Tool Code Maps
+
+The current state of error codes per tool, with mapping to the
+families above. This is the input to harmonization, not the target.
+
+### `mdli`
+
+Stable string codes prefixed `E_`. Already aligned with §2 for
+selector, mutation safety, and validation codes. Maps cleanly to
+families when `category` is added.
+
+### `xli`
+
+Errors documented per command in `tools/xli/README.md`. Partial-fidelity
+warnings on the `umya-spreadsheet` path are emitted as `meta.warnings`
+today; promotion to `E_PARTIAL_FIDELITY` is recommended at the next
+compatible bump.
+
+### `vaultli`
+
+Validation findings (broken sources, duplicate IDs, dangling refs,
+stale index state) surface through `validate`. Recommended: standardize
+on `E_VALIDATION_*` codes for parity with `mdli`.
+
+### `clipli`
+
+Today emits a flattened `{ok, error, code}` form for failure. Codes
+are tool-specific strings (not yet mapped). Recommendation: graduate
+to the structured `error` object and adopt shared codes for
+clipboard-state mismatches.
+
+### `jirali`
+
+Exit codes 0–8 are Jira-shaped (0 success, 1 general, 2 usage,
+3 not-found, 4 permission, 5 conflict, 6 rate-limited, 7 validation,
+8 timeout). Recommendation: surface a `category` in the JSON envelope
+that maps each exit code to a family (e.g. exit 4 → `auth`, exit 6 →
+`runtime`).
+
+### `notionli`
+
+Exit codes per the PRD; `E_AUTH_MISSING` is shared with `framerli`.
+Recommendation: extend coverage with `E_RATE_LIMITED` and
+`E_AUTH_SCOPE` as those scenarios appear in real workflows.
+
+### `framerli`
+
+Stable `E_*` codes including `E_AUTH_MISSING` and `E_NOT_IMPLEMENTED`.
+Error envelope uses `hint` and `retryable` (vs. the platform's
+`suggestion` and `is_retryable`); see the tool's "Platform
+Conformance" section for the planned alignment.
+
+### `deckli` (spec)
+
+Currently uses lowercase string codes (`unknown_command`,
+`shape_not_found`, `no_addin`). Recommendation: graduate to the
+shared `E_*` codes — `no_addin` becomes `E_BRIDGE_DISCONNECTED`,
+`shape_not_found` becomes `E_SELECTOR_NOT_FOUND`, etc., before v1.
+
+### `docli` (spec)
+
+Uses upper-snake codes without an `E_` prefix (e.g. `INVALID_TARGET`).
+Recommendation: add the `E_` prefix and a `category` field at v1; map
+existing names onto the shared registry where the semantics align
+(`INVALID_TARGET` → `E_SELECTOR_NOT_FOUND` in `state` family).
+
+### `bashli` (spec)
+
+Greenfield; should adopt the shared codes from day one. Likely
+candidates: `E_TIMEOUT`, `E_RATE_LIMITED` (where applicable for HTTP
+steps), and a new `E_STEP_FAILED` (family `state`) for non-zero exit
+codes inside the pipeline.
+
+### `vizli`
+
+Should expose `E_TEMPLATE_PARSE`, `E_TEMPLATE_MISSING_DATASET` (already
+in `mdli`'s registry), and a new `E_RENDER_FAILED` (family `runtime`)
+for engine-level failures. Specs at `tools/vizli/PLAN.md` define
+strict-undefined behavior and offline guarantees that map cleanly to
+existing codes once added.
+
+---
+
+## 4. Adding a New Code
+
+When proposing a new shared code:
+
+1. **Confirm no existing code fits.** Check §2; check the per-tool
+   maps in §3.
+2. **Pick a family.** Use the table in §1; the `category` value
+   should be one of `input`, `auth`, `state`, `runtime`, `internal`.
+3. **Decide retryability.** Is this recoverable by the agent without
+   operator action?
+4. **Choose a stable name.** `E_<NOUN>_<CONDITION>`. Avoid tool-specific
+   names; prefer artifact-level concepts.
+5. **Add it to §2 with semantics, retryability, and first use.**
+6. **Open a tracking note** in `tooli_feedback.md` if the new code
+   reveals a gap in the platform spec.
+
+Renames go through the same process; old codes stay in the registry
+under a "deprecated" subsection (to be added the first time it is
+needed) until every tool has migrated.
+
+---
+
+## 5. Recovery Suggestion Conventions
+
+Each error's `suggestion` object should follow this shape (spec §4.5):
+
+```json
+{
+  "action": "retry_with_modified_input",
+  "fix": "Run `mdli id list report.md` to see available IDs.",
+  "example": "mdli section get report.md --id cashplus.okr"
+}
+```
+
+Recommended `action` values for shared codes:
+
+| Code | Typical `action` |
+|---|---|
+| `E_AMBIGUOUS_SELECTOR` | `disambiguate_selector` |
+| `E_SELECTOR_NOT_FOUND` | `retry_with_modified_input` |
+| `E_STALE_PREIMAGE` | `reinspect_and_replan` |
+| `E_BLOCK_MODIFIED` | `resolve_conflict` |
+| `E_BLOCK_LOCKED` | `unlock_or_force` |
+| `E_AUTH_MISSING` | `configure_credentials` |
+| `E_AUTH_INVALID` | `rotate_credentials` |
+| `E_AUTH_SCOPE` | `request_additional_scope` |
+| `E_RATE_LIMITED` | `backoff_and_retry` |
+| `E_BRIDGE_DISCONNECTED` | `start_bridge` |
+| `E_NOT_IMPLEMENTED` | `use_alternative_command` |
+| `E_TIMEOUT` | `increase_timeout_or_split` |
+
+These are guidance, not enforcement. A tool may emit a more specific
+`action` if it serves the agent better.

--- a/docs/tool-roadmap.md
+++ b/docs/tool-roadmap.md
@@ -5,17 +5,51 @@ tool-family notes that lived in `tools/TOOLS.md`.
 
 ## Agent Tool Standards
 
-All tools should be designed for agent consumption:
+The architectural contract for every `*li` tool — envelope shape, error
+taxonomy, mutation safety lifecycle, selector model, schema discovery,
+testing standards, and the new-tool checklist — is defined in
+[`AGENT_TOOLS_PLATFORM_SPEC.md`](AGENT_TOOLS_PLATFORM_SPEC.md). Cross-tool
+error codes are catalogued in [`error-registry.md`](error-registry.md).
 
-- Inputs must be explicit and validated.
-- Outputs should be structured, stable, and documented.
-- Errors should include machine-readable codes and actionable recovery guidance.
-- Mutating commands should support `--dry-run` when possible.
-- Commands should be focused enough to compose with other tools.
-- Human-readable output is welcome, but non-interactive calls should produce JSON
-  or another predictable format.
+In short, every tool should:
+
+- Take explicit, validated inputs.
+- Emit a stable JSON envelope with a `meta` block.
+- Use stable error codes with `category`, `suggestion`, `is_retryable`.
+- Default to safe (dry-run plan) for mutating commands and write atomically.
+- Prefer stable selectors (IDs, A1 ranges, named tables) over names/positions.
+- Compose with other `*li` tools via NDJSON and stdin/stdout.
+
+See the spec for the authoritative form, including envelope deviations
+already in flight.
+
+## Maturity Ladder
+
+The platform spec defines an 8-level maturity ladder (§15). Best-effort
+classifications are reproduced in the tool-family table below; correct in
+place when better evidence exists.
 
 ## Current Tool Families
+
+Quick view (maturity per the platform spec ladder; see each tool's section
+below for detail):
+
+| Tool | Domain | Maturity | Notes |
+|---|---|---:|---|
+| `mdli` | Markdown AST | 7 | PRD Phases 1–8 implemented; cross-tool integration tested via recipes |
+| `xli` | Excel `.xlsx` | 6 | Atomic + fingerprint; `umya-spreadsheet` fallback warnings remain |
+| `vaultli` | File-based knowledge vault | 6 | Rust + Python parity, sidecar model, `INDEX.jsonl` cache |
+| `clipli` | macOS clipboard intelligence | 5 | Capture/templatize/render loop; macOS-only |
+| `jirali` | Jira issues / JQL / sprints | 5 | Live + local-deterministic execution paths |
+| `notionli` | Notion workspace | 4 | MVP shipped; expanding |
+| `framerli` | Framer Server API | 4 | Rust core + Node bridge; mock mode for CI |
+| `barli` | macOS menu bar plugin host | 3 | Hot-reload Python plugins; no test suite |
+| `vizli` | Visualization templates → SVG/PNG/HTML/PDF | 1–2 | Spec stable, implementation in progress |
+| `deckli` | PowerPoint via Office.js bridge | 1 | Spec + add-in/bridge proto |
+| `docli` | Word `.docx` | 0–1 | Spec mature; workspace crates scaffolded |
+| `bashli` | Structured shell execution | 0–1 | Spec; greenfield |
+| `pdfli` | PDF tooling | 0 | Placeholder |
+| `gitli` | GitHub issues, PRs, wiki | 0 | Placeholder |
 
 ### `vaultli`
 

--- a/tools/clipli/CLIPLI_SPEC.md
+++ b/tools/clipli/CLIPLI_SPEC.md
@@ -1442,3 +1442,33 @@ pb::write(&[(PbType::Html, rendered.html.as_bytes()), (PbType::PlainText, render
 - [ ] README.md, man page
 - [ ] CI (GitHub Actions, macOS runner)
 - [ ] Homebrew formula
+
+---
+
+## 14. Platform Conformance
+
+`clipli` is at maturity level 5 against
+[`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](../../docs/AGENT_TOOLS_PLATFORM_SPEC.md):
+shipped, with a SKILL.md, but predating envelope harmonization.
+
+Known deviations from the recommended platform envelope (spec §4.4 and
+§4.5):
+
+- The minimal failure form documented in `README.md`
+  (`{"ok": false, "error": "message", "code": "ERROR_CODE"}`) flattens
+  the error object and uses a top-level `code`. Recommendation:
+  graduate to the full `error: { code, category, message, suggestion,
+  is_retryable, details }` shape for v1.1, keeping the current shape
+  emit-compatible during a deprecation window.
+- Error codes lack a `category` family. See
+  [`docs/error-registry.md`](../../docs/error-registry.md) for the
+  shared registry.
+- `clipli` is macOS-only and clipboard-bound; `doctor` is the platform's
+  recommended preflight surface for environment readiness — keep it
+  current as new capabilities ship.
+
+The capture → templatize → render → paste loop is `clipli`'s analog of
+the platform's plan-first mutation model. The clipboard *is* the
+artifact; preimage protection against another app rewriting the
+clipboard between `inspect` and `write` is an open question worth
+tracking once concurrent-app scenarios appear in real workflows.

--- a/tools/deckli/DECKLI_SPECS.md
+++ b/tools/deckli/DECKLI_SPECS.md
@@ -656,3 +656,34 @@ This gives Claude Code direct tool access without shelling out. The MCP server i
 5. **Zero-config for agents**: `deckli mcp-serve` in Claude Code settings.json, start using immediately
 6. **SKILL.md < 4K tokens**: Primary skill file fits in context without crowding reasoning
 7. **Self-healing > 80%**: Agent recovers from errors without human intervention 4/5 times
+
+---
+
+## Platform Conformance
+
+`deckli` is at maturity level 1 against
+[`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](../../docs/AGENT_TOOLS_PLATFORM_SPEC.md)
+(spec + add-in/bridge prototype).
+
+Known deviations from the recommended platform envelope (spec §4.4 and
+§4.5) that the v1 implementation should reconcile:
+
+- Envelope uses `success` instead of `ok`. Recommendation: rename to
+  `ok` to align with every other `*li` tool before v1 stabilizes — the
+  cost is nil and divergence here will leak into agent prompts.
+- Per-message `command` and `timing_ms` are top-level. Recommendation:
+  keep `command` (useful routing context) but fold `timing_ms` into a
+  `meta` block alongside `tool`, `version`, and `dry_run`.
+- Error `suggestion` is a string. Recommendation: align with the
+  platform's `suggestion` object (`action`, `fix`, `example`) so agents
+  get structured recovery advice. See spec §4.5.
+- A new platform-level error class `E_BRIDGE_DISCONNECTED` covers the
+  current `no_addin` case; adopt the platform code so handlers are
+  shared with `framerli` and any future live-bridge tool. See
+  [`docs/error-registry.md`](../../docs/error-registry.md).
+
+Mutation safety for live documents is special: there is no preimage
+hash because the artifact is a running PowerPoint instance. The
+batch + context.sync model and `render --slide` visual verification
+loop are `deckli`'s equivalents of the platform's
+plan → apply → validate cycle.

--- a/tools/docli/docli-spec.md
+++ b/tools/docli/docli-spec.md
@@ -2167,3 +2167,30 @@ docli inspect --help
 ```
 
 No Python. No Node.js. No package managers. One binary, zero runtime dependencies.
+
+---
+
+## Platform Conformance
+
+`docli` is at maturity level 0–1 against
+[`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](../../docs/AGENT_TOOLS_PLATFORM_SPEC.md)
+(spec mature, implementation scaffolded).
+
+Known deviations from the recommended platform envelope (spec §4.4 and
+§4.5) that the implementation should reconcile or document:
+
+- Success envelope uses `data` instead of `result` and a top-level
+  `command` field. Recommendation: keep `command` (it carries useful
+  routing context) but rename `data` → `result` to align with the
+  platform contract before declaring v1 stable.
+- Top-level `elapsed_ms` instead of `meta.duration_ms`. Recommendation:
+  fold into a `meta` block alongside `tool`, `version`, and `dry_run`.
+- Error code uses upper-snake strings without an `E_` prefix
+  (e.g. `INVALID_TARGET`). Recommendation: add the `E_` prefix and a
+  `category` field mapped to the spec's `E1xxx`–`E5xxx` families. See
+  [`docs/error-registry.md`](../../docs/error-registry.md).
+
+The shadow-package atomic commit pipeline, durability modes, hard
+invariants, and the inspect → plan → apply → validate → diff lifecycle
+already align tightly with the platform's mutation safety model
+(spec §6).

--- a/tools/framerli/README.md
+++ b/tools/framerli/README.md
@@ -143,3 +143,24 @@ Error:
   "meta": {}
 }
 ```
+
+## Platform Conformance
+
+`framerli` is at maturity level 4 against
+[`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](../../docs/AGENT_TOOLS_PLATFORM_SPEC.md).
+
+Known deviations from the recommended platform envelope (spec §4.4 and
+§4.5):
+
+- Success envelope uses `data` instead of `result`. Reason: shipped before
+  the platform spec consolidated naming. Harmonization is an open roadmap
+  item; the field name is stable for live integrations.
+- Error envelope uses `hint` and `retryable` instead of the spec's
+  `suggestion` and `is_retryable`. Same reason.
+- Error codes are stable string codes (`E_AUTH_MISSING`,
+  `E_NOT_IMPLEMENTED`, ...) without a numeric `category` family. See
+  [`docs/error-registry.md`](../../docs/error-registry.md) for the
+  registry; agents can map string codes to spec families there.
+
+Mutation safety, dry-run-by-default, audit logging, and approval gates
+follow the platform contract.

--- a/tools/notionli/SKILL.md
+++ b/tools/notionli/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: notionli
+description: |
+  Use notionli for agent-safe Notion workspace operations: search, page
+  reads, block edits, database (data source) inspection, row upserts by
+  external key, comments, and user lookups. Writes default to a dry-run
+  plan; pass `--apply` to commit. Trigger on: "update Notion", "search
+  the workspace", "upsert a Notion row", "create a Notion comment",
+  "find the Notion page about X", "Notion database schema", or any task
+  where an agent needs to read or mutate Notion content with auditable,
+  rehearsable commands.
+---
+
+# notionli
+
+`notionli` is a Rust Notion CLI built for autonomous agents first and
+human terminal users second. It provides JSON envelopes, structured
+errors, dry-run-by-default writes, local profile state with aliases
+and audit, and integration-token auth via `NOTION_API_KEY`,
+`--token-cmd`, or the macOS Keychain.
+
+The full operator-facing reference is
+[`README.md`](./README.md). The platform contract is in
+[`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](../../docs/AGENT_TOOLS_PLATFORM_SPEC.md).
+
+## When to use notionli
+
+- Search a Notion workspace for pages, databases, or blocks.
+- Inspect a database (data source) schema before writing rows.
+- Upsert rows into a Notion database by an external key (idempotent).
+- Read a page's blocks for an agent context window.
+- Add or read comments on a page or block.
+- Resolve a known Notion target via aliases instead of long UUIDs.
+- Rehearse a write workflow against a real workspace without touching
+  it (dry-run is the default).
+
+## When **not** to use notionli
+
+- The task is to bulk-export a workspace — Notion's official export is
+  a better fit.
+- The task is rich-text editing of long-form Notion pages — `notionli`
+  exposes structured operations, not a Notion editor.
+- The task is to drive Markdown documents — use `mdli` and emit Notion
+  rows separately if a Notion sync is also required.
+
+## Agent Contract
+
+- stdout in non-TTY mode is the JSON envelope; diagnostics go to
+  stderr.
+- **Writes are dry-run by default.** Pass `--apply` to commit.
+- Mutations append to a local audit log and create operation
+  receipts under `~/.local/share/notionli`.
+- Address content by Notion UUID. Create aliases for ergonomics:
+
+  ```bash
+  notionli alias set tasks data_source:248104cd477e80afbc30000bd28de8f9
+  ```
+
+- Resolve a default selected target with `notionli use <alias>`; then
+  subsequent commands can address `.` instead of the alias.
+- Auth precedence: `--token-cmd` → `NOTION_API_KEY` → Keychain entry.
+
+## Recommended Workflows
+
+### 1. First-time setup
+
+```bash
+export NOTION_API_KEY=secret_...
+notionli auth whoami
+notionli alias set tasks data_source:<uuid>
+notionli use tasks
+```
+
+### 2. Search the workspace
+
+```bash
+notionli search "Q3 launch plan" --json
+```
+
+### 3. Inspect a database before writing
+
+```bash
+notionli ds show tasks --json
+notionli schema --command "row upsert"
+```
+
+Use this to learn the property schema before composing an upsert.
+
+### 4. Idempotent row upsert by external key
+
+```bash
+notionli row upsert tasks \
+  --key ExternalID=gh:123 \
+  --set "Status=In Progress" \
+  --set "Title=Fix the dashboard"
+```
+
+This is a dry-run plan. To commit:
+
+```bash
+notionli row upsert tasks --key ExternalID=gh:123 --set "Status=Done" --apply
+```
+
+### 5. Read page context for an agent prompt
+
+```bash
+notionli page show <page-uuid> --json
+notionli block list <page-uuid> --json
+```
+
+### 6. Audit and re-apply a recorded operation
+
+```bash
+notionli op list
+notionli op show <receipt-id>
+```
+
+## Failure Recovery
+
+| Symptom | What to do |
+|---|---|
+| `E_AUTH_MISSING` | Confirm `NOTION_API_KEY` (or `--token-cmd` / Keychain entry); re-run `notionli auth whoami`. |
+| Property not found on upsert | Run `notionli ds show <alias>` and confirm the property name (case-sensitive). |
+| Rate-limited (429) | Honor the retry-after; back off and re-issue. Treat as retryable. |
+| Plan looks wrong in dry-run | Adjust `--set` flags. Never re-run with `--apply` until the plan reads correctly. |
+| Stale alias | `notionli alias set <name> <uuid>` overwrites; `notionli alias list` to audit. |
+
+## Schema discovery
+
+```bash
+notionli schema
+notionli schema --command "row upsert"
+notionli tools         # implementation status by command group
+```
+
+`notionli tools` is especially useful for an agent that needs to know
+which command surfaces are live versus stubbed.

--- a/tools/xli/SKILL.md
+++ b/tools/xli/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: xli
+description: |
+  Use xli for deterministic, JSON-first Excel workbook operations:
+  inspect, read, write, format, batch edits, sheet management, workbook
+  creation from CSV/Markdown/JSON, and built-in template application.
+  Trigger on: "edit this xlsx", "build a workbook", "format that range",
+  "create an Excel report from this CSV", "inspect the spreadsheet",
+  "validate the workbook", "atomic commit on .xlsx", or any task where
+  an agent needs to manipulate `.xlsx` files without driving Excel.
+---
+
+# xli
+
+`xli` is a Rust CLI for deterministic, agent-safe Excel workbook
+operations. It is the right tool whenever the artifact is a `.xlsx`
+file on disk and the agent needs to *modify* it, not just read it.
+
+The full operator-facing reference is
+[`README.md`](./README.md). The platform contract `xli` follows is in
+[`docs/AGENT_TOOLS_PLATFORM_SPEC.md`](../../docs/AGENT_TOOLS_PLATFORM_SPEC.md).
+
+## When to use xli
+
+- Build an Excel report from prepared CSV / NDJSON / JSON rows.
+- Inspect an unknown workbook before deciding what to do with it.
+- Update a single cell, formula, range, or sheet inside an existing
+  workbook with atomic commit semantics.
+- Apply a batch of micro-ops in one transaction.
+- Format a range with number formats, fills, fonts, alignment, and
+  column widths.
+- Validate or lint a workbook before handing it to a stakeholder.
+- Apply a built-in template (e.g. `basic-table-format`) to part of a
+  workbook.
+
+## When **not** to use xli
+
+- You need to drive a *running* Excel instance — `xli` operates on
+  files, not on the live application.
+- You need to render a chart artifact (image) — use `vizli`.
+- You need pandas-style validation, reconciliation, or report
+  generation — use `xli-companion` (Python).
+- You need to manipulate decks or Word documents — use `deckli` /
+  `docli`.
+
+## Agent Contract
+
+- stdout in non-TTY mode is the JSON envelope; diagnostics go to stderr.
+- `--json` forces JSON envelope on stdout.
+- Mutating commands write atomically and may emit a warning on the
+  `umya-spreadsheet` fallback path. **Always check `meta.warnings`** on
+  workbooks containing charts, drawings, macros, data validation, or
+  complex tables — fidelity may be reduced for those features.
+- Mutating commands accept a fingerprint for compare-and-swap; refuse
+  on stale input.
+- Address content with `Sheet!A1` (cell), `Sheet!A1:B10` (range), or
+  named tables / named ranges where they exist. Avoid sheet *index*
+  addressing because sheet renames break it.
+- Selector resolution order: named table → named range → A1 selector.
+
+## Recommended Workflows
+
+### 1. Inspect before mutating
+
+```bash
+xli inspect workbook.xlsx --json
+```
+
+Returns workbook metadata, sheet names, dimensions, and fingerprints.
+Use this to confirm shape before writing.
+
+### 2. Build a formatted report from CSV
+
+```bash
+xli create /tmp/report.xlsx \
+  --from-csv data.csv \
+  --title "Revenue Report" \
+  --col Account \
+  --col Revenue:currency:right \
+  --hide InternalNotes \
+  --rename Account:Customer \
+  --total-row
+```
+
+### 3. Atomic single-cell write with formula
+
+```bash
+xli write workbook.xlsx "Summary!B2" --formula "=SUM(Data!B:B)"
+```
+
+### 4. Batch edits in one commit
+
+```bash
+printf '%s\n' \
+  '{"op":"write","address":"Summary!A1","value":"Revenue"}' \
+  '{"op":"format","range":"Summary!A1:B1","bold":true,"fill":"4472C4","font_color":"FFFFFF"}' \
+  | xli batch workbook.xlsx --stdin
+```
+
+### 5. Apply a built-in template
+
+```bash
+xli template list
+xli template preview basic-table-format --param range=Summary!A1:B10
+xli apply workbook.xlsx basic-table-format --param range=Summary!A1:B10
+```
+
+### 6. Pre-handoff quality gate
+
+```bash
+xli lint workbook.xlsx
+xli doctor workbook.xlsx --skip-recalc
+xli validate workbook.xlsx
+```
+
+## Failure Recovery
+
+| Symptom | What to do |
+|---|---|
+| `umya-spreadsheet fallback` warning on a chart-bearing workbook | Re-inspect; consider whether artifact-sensitive features survived. Fall back to manual review for compliance-critical files. |
+| Fingerprint mismatch on write | Re-inspect to refresh the fingerprint, then retry. Another writer touched the file. |
+| `recalc` fails | LibreOffice is required; check `xli doctor`. Skip recalc if the workbook does not need formula evaluation. |
+| Unknown sheet error | Run `xli inspect` and address by exact sheet name (case-sensitive). |
+| Range out of bounds | `xli inspect --range` to confirm the dimension before writing. |
+
+## Companion: `xli-companion` (Python)
+
+Reach for `xli-companion` when the task is heavier than addressable
+mutation: dataframe validation, reconciliation against source data,
+OOXML artifact audits, optional real-engine checks, or report
+rendering. It complements `xli`; it does not replace it.
+
+## Schema discovery
+
+```bash
+xli schema                     # full schema
+xli schema --command create    # one command
+xli schema --result FormatOutput
+```
+
+Use this to learn the exact shape of inputs/outputs before composing
+batch ops or wiring `xli` into another tool.


### PR DESCRIPTION
Introduce docs/AGENT_TOOLS_PLATFORM_SPEC.md as the architectural contract
for the whole platform: design philosophy, command contract, JSON
envelope, error taxonomy, mutation safety model, selector model, tool
family taxonomy, cross-tool workflows, skill integration, schema
discovery, testing standards, language strategy, doc standards, maturity
ladder, open questions, and a new-tool checklist.

Distinguishes implemented, partial, planned, and recommended behavior;
records existing envelope deviations rather than rewriting tool history.